### PR TITLE
calling UIApplication.isProtectedDataAvailable from main thread

### DIFF
--- a/CSAppMenuSDK/AppManager.swift
+++ b/CSAppMenuSDK/AppManager.swift
@@ -91,9 +91,11 @@ public class AppManager: AppManagerApi
     fileprivate func attemptToLoadAppInfoFromDefaults()
     {
         if self.appInformation == nil{
-            if UIApplication.shared.isProtectedDataAvailable{
-                if let cachedAppInfoData:Data = UserDefaults.standard.object(forKey: appId) as? Data{
-                    self.appInformation = NSKeyedUnarchiver.unarchiveObject(with: cachedAppInfoData) as? AppInformation
+            DispatchQueue.main.async {
+                if UIApplication.shared.isProtectedDataAvailable{
+                    if let cachedAppInfoData:Data = UserDefaults.standard.object(forKey: self.appId) as? Data{
+                        self.appInformation = NSKeyedUnarchiver.unarchiveObject(with: cachedAppInfoData) as? AppInformation
+                    }
                 }
             }
         }


### PR DESCRIPTION
<img width="649" alt="screen shot 2018-05-04 at 13 52 46" src="https://user-images.githubusercontent.com/2852881/39626949-4b464ec4-4fa4-11e8-9851-75be73497c49.png">

prevent ui from glitching